### PR TITLE
Add a crate for the adafruit nrf52 board

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,18 +1,28 @@
-target remote :3333
+# print demangled symbols by default
+set print asm-demangle on
 
-monitor arm semihosting enable
+# JLink
+target extended-remote :2331
+monitor flash breakpoints 1
+# allow hprints to show up in gdb
+monitor semihosting enable
+monitor semihosting IOClient 3
 
-# # send captured ITM to the file itm.fifo
-# # (the microcontroller SWO pin must be connected to the programmer SWO pin)
-# # 8000000 must match the core clock frequency
+monitor reset
+load
+
+# OpenOCD
+#target extended-remote :3333
+#monitor arm semihosting enable
+# send captured ITM to the file itm.fifo
+# (the microcontroller SWO pin must be connected to the programmer SWO pin)
+# 8000000 must match the core clock frequency
 # monitor tpiu config internal itm.fifo uart off 8000000
-
-# # OR: make the microcontroller SWO pin output compatible with UART (8N1)
-# # 2000000 is the frequency of the SWO pin
+# OR: make the microcontroller SWO pin output compatible with UART (8N1)
+# 2000000 is the frequency of the SWO pin
 # monitor tpiu config external uart off 8000000 2000000
-
-# # enable ITM port 0
+# enable ITM port 0
 # monitor itm port 0 on
 
-load
-step
+#load
+#step

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/target/
-/*-hal/target/
+target
+.gdb_history
+[._]*.sw[a-p]
 **/*.rs.bk
 Cargo.lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ addons:
 script:
   - rustup target add thumbv7em-none-eabihf
   - cargo build
+  - cargo build --examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
-members = ["nrf52-hal", "nrf52840-hal"]
+members = [
+  "boards/adafruit_nrf52pro",
+  "nrf52-hal",
+  "nrf52840-hal",
+]
 
 [profile.dev]
 incremental = false

--- a/boards/adafruit_nrf52pro/Cargo.toml
+++ b/boards/adafruit_nrf52pro/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["Wez Furlong <wez@wezfurlong.org>"]
+categories = ["embedded", "hardware-support", "no-std"]
+description = "Support for Adafruit nRF52 Feathers"
+keywords = ["arm", "cortex-m", "nrf52", "hal"]
+license = "MIT OR Apache-2.0"
+name = "adafruit_nrf52pro"
+repository = "https://github.com/nrf-rs/nrf52"
+version = "0.0.1"
+
+[dependencies]
+nrf52-hal = { path = "../../nrf52-hal" }
+
+[dev-dependencies]
+cortex-m-rt = "~0.5"
+cortex-m-semihosting = "~0.3"
+panic-semihosting = "~0.3"
+nb = "~0.1"
+
+[features]
+rt = ["nrf52-hal/rt"]
+default = ["rt"]

--- a/boards/adafruit_nrf52pro/examples/blinky.rs
+++ b/boards/adafruit_nrf52pro/examples/blinky.rs
@@ -1,0 +1,44 @@
+#![no_main]
+#![no_std]
+
+#[macro_use]
+extern crate cortex_m_rt;
+#[macro_use]
+extern crate nb;
+
+extern crate adafruit_nrf52pro;
+extern crate panic_semihosting;
+
+use adafruit_nrf52pro::hal::{prelude::*, timer::Timer};
+use adafruit_nrf52pro::nrf52::{Peripherals};
+use adafruit_nrf52pro::Pins;
+
+entry!(main);
+
+fn main() -> ! {
+    let p = Peripherals::take().unwrap();
+    let pins = Pins::new(p.P0.split());
+
+    let mut led1 = pins.led1.into_push_pull_output();
+    let mut led2 = pins.led2.into_push_pull_output();
+
+    let mut timer = p.TIMER0.constrain();
+
+    // Alternately flash the red and blue leds
+    loop {
+        led1.set_low();
+        led2.set_high();
+        delay(&mut timer, 250_000); // 250ms
+        led1.set_high();
+        led2.set_low();
+        delay(&mut timer, 1_000_000); // 1s
+    }
+}
+
+fn delay<T>(timer: &mut Timer<T>, cycles: u32)
+where
+    T: TimerExt,
+{
+    timer.start(cycles);
+    block!(timer.wait());
+}

--- a/boards/adafruit_nrf52pro/src/lib.rs
+++ b/boards/adafruit_nrf52pro/src/lib.rs
@@ -1,0 +1,63 @@
+#![no_std]
+pub extern crate nrf52_hal as hal;
+use hal::gpio::{p0, Floating, Input};
+pub use hal::nrf52;
+
+/// Maps the pins to the names printed on the device
+pub struct Pins {
+    pub a0: p0::P0_2<Input<Floating>>,
+    pub a1: p0::P0_3<Input<Floating>>,
+    pub a2: p0::P0_4<Input<Floating>>,
+    pub a3: p0::P0_5<Input<Floating>>,
+    pub a4: p0::P0_28<Input<Floating>>,
+    pub a5: p0::P0_29<Input<Floating>>,
+    pub sck: p0::P0_12<Input<Floating>>,
+    pub mosi: p0::P0_13<Input<Floating>>,
+    pub miso: p0::P0_14<Input<Floating>>,
+    pub txd: p0::P0_8<Input<Floating>>,
+    pub rxd: p0::P0_6<Input<Floating>>,
+    pub dfu: p0::P0_20<Input<Floating>>,
+    pub frst: p0::P0_22<Input<Floating>>,
+    pub d16: p0::P0_16<Input<Floating>>,
+    pub d15: p0::P0_15<Input<Floating>>,
+    pub d7: p0::P0_7<Input<Floating>>,
+    pub d11: p0::P0_11<Input<Floating>>,
+    pub a7: p0::P0_31<Input<Floating>>,
+    pub a6: p0::P0_30<Input<Floating>>,
+    pub d27: p0::P0_27<Input<Floating>>,
+    pub scl: p0::P0_26<Input<Floating>>,
+    pub sda: p0::P0_25<Input<Floating>>,
+    pub led1: p0::P0_17<Input<Floating>>,
+    pub led2: p0::P0_19<Input<Floating>>,
+}
+
+impl Pins {
+    pub fn new(pins: p0::Parts) -> Self {
+        Self {
+            a0: pins.p0_2,
+            a1: pins.p0_3,
+            a2: pins.p0_4,
+            a3: pins.p0_5,
+            a4: pins.p0_28,
+            a5: pins.p0_29,
+            sck: pins.p0_12,
+            mosi: pins.p0_13,
+            miso: pins.p0_14,
+            txd: pins.p0_8,
+            rxd: pins.p0_6,
+            dfu: pins.p0_20,
+            frst: pins.p0_22,
+            d16: pins.p0_16,
+            d15: pins.p0_15,
+            d7: pins.p0_7,
+            d11: pins.p0_11,
+            a7: pins.p0_31,
+            a6: pins.p0_30,
+            d27: pins.p0_27,
+            scl: pins.p0_26,
+            sda: pins.p0_25,
+            led1: pins.p0_17,
+            led2: pins.p0_19,
+        }
+    }
+}


### PR DESCRIPTION
At this stage it is convenient to have some board support crates
in this same repo; it makes it easier to test and understand API
changes, and simpler for CI.

I don't know how many variants of the nrf52 boards are out there
and in common use, so there may well be a point at which we decide
to split off the boards directories.

All this crate does is define some nicer names for the pins and
includes a blinky example that I've flashed to my device.